### PR TITLE
Fix the "comparison of constant -1 with expression of type 'enum Type' is always true" warning

### DIFF
--- a/symbol.c
+++ b/symbol.c
@@ -763,7 +763,7 @@ Symbol* finishComplexMode(char *name, enum Type type) {
     }
     complex_mode->secondary_type = type;
     enum Type illegal_type = isComplexIllegal(type);
-    if (illegal_type != -1) {
+    if (illegal_type != (enum Type)-1) {
         if (name != NULL)
             free(name);
         throw_error(E_ILLEGAL_ELEMENT_TYPE_FOR_TYPED_LIST, getTypeName(illegal_type), complex_mode->name);


### PR DESCRIPTION
## Pull Request Details

Fix of `if (illegal_type != -1) { ... }`.

### Description

**Error fixed:**

```
symbol.c:760:22: error: comparison of constant -1 with expression of type 'enum Type' is always true
      [-Werror,-Wtautological-constant-out-of-range-compare]
    if (illegal_type != -1) {
        ~~~~~~~~~~~~ ^  ~~
1 error generated.
```