### PR TITLE
fix: Lint requirements.sh

### DIFF
--- a/requirements.sh
+++ b/requirements.sh
@@ -6,23 +6,22 @@ if [[ "$OSTYPE" == "linux"* ]]; then
     YUM_CMD=$(which yum)
     DNF_CMD=$(which dnf)
     PACMAN_CMD=$(which pacman)
-    PKG_CMD=$(which pkg)
     APK_CMD=$(which apk)
 
-    if [[ ! -z $APT_CMD ]]; then
+    if [[ -n $APT_CMD ]]; then
         apt update && \
         apt install -y build-essential rsync clang bison flex libreadline-dev
-    elif [[ ! -z $APT_GET_CMD ]]; then
+    elif [[ -n $APT_GET_CMD ]]; then
         apt-get update && \
         apt-get install -y build-essential rsync clang bison flex libreadline-dev
-    elif [[ ! -z $YUM_CMD ]]; then
+    elif [[ -n $YUM_CMD ]]; then
         yum install -y rsync clang flex bison readline-devel
-    elif [[ ! -z $DNF_CMD ]]; then
+    elif [[ -n $DNF_CMD ]]; then
         dnf install -y rsync clang flex bison readline-devel
-    elif [[ ! -z $PACMAN_CMD ]]; then
+    elif [[ -n $PACMAN_CMD ]]; then
         pacman -Syu --noconfirm && \
         pacman -S --noconfirm base-devel rsync clang bison flex readline
-    elif [[ ! -z $APK_CMD ]]; then
+    elif [[ -n $APK_CMD ]]; then
         apk update && \
         apk add build-base rsync clang bison flex readline-dev
     else


### PR DESCRIPTION
## Pull Request Details

`requirements.sh` has been linted.

### Description

`requirements.sh` had two visible linting errors:

1) There was an unused variable
2) the `! -z` test is the equivalent of the `-n` test. The latter is the correct option to use.

### Related Issue

#91 

### Motivation and Context

It's always good to improve any utility scripts.

### How Has This Been Tested

Tested on Arch Linux.

### Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
