### PR TITLE
Replace Bash scripts with POSIX sh scripts

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 make clean && \
 make bench && \

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 export LLVM_PROFILE_FILE="$PWD/.coverage/chaos-%p.profraw" && \
 make clean && \
@@ -13,7 +13,7 @@ make test-official-spells && \
 make rosetta-install-clang && \
 make rosetta-test && \
 make rosetta-test-compiler && \
-llvm-profdata merge -output=chaos.profdata $PWD/.coverage/chaos-*.profraw && \
+llvm-profdata merge -output=chaos.profdata "$PWD/.coverage/chaos-*.profraw && \
 rm $PWD/.coverage/chaos-*.profraw && \
 llvm-cov show /usr/local/bin/chaos -instr-profile=chaos.profdata > coverage.txt && \
 llvm-cov report /usr/local/bin/chaos -instr-profile=chaos.profdata -use-color && \
@@ -26,4 +26,4 @@ llvm-cov show /usr/local/bin/chaos -instr-profile=chaos.profdata \
     ./parser/*.c \
     ./preemptive/*.c \
     ./utilities/*.c \
-    -path-equivalence -use-color --format html > /tmp/coverage.html
+    -path-equivalence -use-color --format html > /tmp/coverage.html"

--- a/profile.sh
+++ b/profile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "Compiling with -fprofile-generate"
 make clean && \

--- a/tests/cli_args.sh
+++ b/tests/cli_args.sh
@@ -1,71 +1,71 @@
-#!/bin/bash
+#!/bin/sh
 
-echo -e "\nINFO: Test the positional arguments (interpreter)\n"
-chaos tests/everything.kaos && echo -e "\nOK\n\n" && \
-chaos -d tests/everything.kaos && echo -e "\nOK\n\n" && \
+printf "\nINFO: Test the positional arguments (interpreter)\n"
+chaos tests/everything.kaos && printf "\nOK\n\n" && \
+chaos -d tests/everything.kaos && printf "\nOK\n\n" && \
 
-echo -e "\nINFO: Test no arguments (REPL)\n"
-echo "exit" | chaos && echo -e "\nOK\n\n" && \
-echo "exit" | chaos -d && echo -e "\nOK\n\n" && \
+printf "\nINFO: Test no arguments (REPL)\n"
+echo "exit" | chaos && printf "\nOK\n\n" && \
+echo "exit" | chaos -d && printf "\nOK\n\n" && \
 
-echo -e "\nINFO: Test compilation variants with short options\n"
+printf "\nINFO: Test compilation variants with short options\n"
 chaos -c tests/everything.kaos && \
     [ -f build/main ] && \
-    echo -e "\nOK\n\n" && \
+    printf "\nOK\n\n" && \
 chaos -c tests/everything.kaos -o everything && \
     [ -f build/everything ] && \
-    echo -e "\nOK\n\n" && \
+    printf "\nOK\n\n" && \
 chaos -c tests/everything.kaos -o everything -e "-ggdb" && \
     [ -f build/everything ] && \
-    echo -e "\nOK\n\n" && \
+    printf "\nOK\n\n" && \
 chaos -c tests/everything.kaos -o everything -e "-ggdb" -k && \
     [ -f build/everything ] && \
     [ -f build/everything.c ] && \
     [ -f build/everything.h ] && \
-    echo -e "\nOK\n\n" && \
+    printf "\nOK\n\n" && \
 chaos -c tests/everything.kaos -o everything -e "-ggdb" -kd && \
     [ -f build/everything ] && \
     [ -f build/everything.c ] && \
     [ -f build/everything.h ] && \
-    echo -e "\nOK\n\n" && \
+    printf "\nOK\n\n" && \
 
-echo -e "\nINFO: Test compilation variants with long options\n"
+printf "\nINFO: Test compilation variants with long options\n"
 chaos --compile tests/everything.kaos && \
     [ -f build/main ] && \
-    echo -e "\nOK\n\n" && \
+    printf "\nOK\n\n" && \
 chaos --compile tests/everything.kaos --output everything && \
     [ -f build/everything ] && \
-    echo -e "\nOK\n\n" && \
+    printf "\nOK\n\n" && \
 chaos --compile tests/everything.kaos --output everything --extra "-ggdb" && \
     [ -f build/everything ] && \
-    echo -e "\nOK\n\n" && \
+    printf "\nOK\n\n" && \
 chaos --compile tests/everything.kaos --output everything --extra "-ggdb" --keep && \
     [ -f build/everything ] && \
     [ -f build/everything.c ] && \
     [ -f build/everything.h ] && \
-    echo -e "\nOK\n\n" && \
+    printf "\nOK\n\n" && \
 chaos --compile tests/everything.kaos --output everything --extra "-ggdb" --keep --debug && \
     [ -f build/everything ] && \
     [ -f build/everything.c ] && \
     [ -f build/everything.h ] && \
-    echo -e "\nOK\n\n" && \
+    printf "\nOK\n\n" && \
 
-echo -e "\nINFO: Test other arguments\n"
+printf "\nINFO: Test other arguments\n"
 chaos -h && chaos --help && \
 chaos -v && chaos --version && \
 chaos -l && chaos --license && \
 chaos -u tests/everything.kaos && chaos --unsafe tests/everything.kaos && \
-echo -e "\nOK\n\n" && \
+printf "\nOK\n\n" && \
 
-echo -e "\nINFO: Test invalid argument messages with short options\n"
-chaos -c || echo -e "\nOK\n\n" && \
-chaos -c tests/everything.kaos -o || echo -e "\nOK\n\n" && \
-chaos -o everything || echo -e "\nOK\n\n" && \
-chaos -c tests/everything.kaos -o everything -e || echo -e "\nOK\n\n" && \
+printf "\nINFO: Test invalid argument messages with short options\n"
+chaos -c || printf "\nOK\n\n" && \
+chaos -c tests/everything.kaos -o || printf "\nOK\n\n" && \
+chaos -o everything || printf "\nOK\n\n" && \
+chaos -c tests/everything.kaos -o everything -e || printf "\nOK\n\n" && \
 
-echo -e "\nINFO: Test other erroring arguments\n"
+printf "\nINFO: Test other erroring arguments\n"
 chaos --no_such_arg || \
 chaos no_such_file.kaos || \
-echo -e "\nOK\n\n" && \
+printf "\nOK\n\n" && \
 
-echo -e "\nINFO: CLI arguments are OK."
+printf "\nINFO: CLI arguments are OK."

--- a/tests/compiler.sh
+++ b/tests/compiler.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 extra_flags=""
 EXTRA_FLAGS_ENABLED=false
@@ -19,27 +19,27 @@ while getopts ":e:" opt; do
     esac
 done
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
 
 failed=false
 
-for filepath in $(find $DIR -maxdepth 1 -name '*.kaos'); do
-    filename=$(basename $filepath)
+for filepath in $(find "$DIR" -maxdepth 1 -name '*.kaos'); do
+    filename=$(basename "$filepath")
     testname="${filename%.*}"
-    out=$(<"$DIR/$testname.out")
+    out=$(cat "$DIR/$testname.out")
 
     SKIP_TESTS="syntax_error preemptive"
 
-    if echo $SKIP_TESTS | grep -w $testname > /dev/null; then
+    if echo "$SKIP_TESTS" | grep -w "$testname" > /dev/null; then
         continue
     fi
 
     echo "(compiler) Compiling test: ${testname}"
 
     if [ "$EXTRA_FLAGS_ENABLED" = true ] ; then
-        cout=$(chaos -c tests/$filename -o $testname -e "$extra_flags" 2>&1)
+        cout=$(chaos -c "tests/$filename" -o "$testname" -e "$extra_flags" 2>&1)
     else
-        cout=$(chaos -c tests/$filename -o $testname 2>&1)
+        cout=$(chaos -c "tests/$filename" -o "$testname" 2>&1)
     fi
     status=$?
 
@@ -53,21 +53,21 @@ for filepath in $(find $DIR -maxdepth 1 -name '*.kaos'); do
     fi
 done
 
-for filepath in $(find $DIR -maxdepth 1 -name '*.kaos'); do
-    filename=$(basename $filepath)
+for filepath in $(find "$DIR" -maxdepth 1 -name '*.kaos'); do
+    filename=$(basename "$filepath")
     testname="${filename%.*}"
-    out=$(<"$DIR/$testname.out")
+    out=$(cat "$DIR/$testname.out")
 
     SKIP_TESTS="syntax_error preemptive"
 
-    if echo $SKIP_TESTS | grep -w $testname > /dev/null; then
+    if echo "$SKIP_TESTS" | grep -w "$testname" > /dev/null; then
         continue
     fi
 
     echo "(compiler) Running test: ${testname}"
 
-    test=$(build/$testname 2>&1)
-    if [ "$test" == "$out" ]
+    test=$("build/$testname" 2>&1)
+    if [ "$test" = "$out" ]
     then
         echo "OK"
     else

--- a/tests/interpreter.sh
+++ b/tests/interpreter.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 
-OPTS=`getopt \
+OPTS=$(getopt \
 -o ns --long no-shell \
--- "$@"`
+-- "$@")
 if [ $? != 0 ] ; then echo "Failed parsing options." >&2 ; exit 1 ; fi
 eval set -- "$OPTS"
 
@@ -24,19 +24,19 @@ while true; do
 done
 
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
 
 failed=false
 
-for filepath in $(find $DIR -maxdepth 1 -name '*.kaos'); do
-    filename=$(basename $filepath)
+for filepath in $(find "$DIR" -maxdepth 1 -name '*.kaos'); do
+    filename=$(basename "$filepath")
     testname="${filename%.*}"
-    out=$(<"$DIR/$testname.out")
+    out=$(cat "$DIR/$testname.out")
 
     echo "(interpreter) Running test: ${testname}"
 
-    test=$(chaos tests/$filename 2>&1)
-    if [ "$test" == "$out" ]
+    test=$(chaos "tests/$filename" 2>&1)
+    if [ "$test" = "$out" ]
     then
         echo "OK"
     else
@@ -46,14 +46,14 @@ for filepath in $(find $DIR -maxdepth 1 -name '*.kaos'); do
     fi
 done
 
-for filepath in $(find $DIR -maxdepth 1 -name '*.kaos'); do
-    filename=$(basename $filepath)
+for filepath in $(find "$DIR" -maxdepth 1 -name '*.kaos'); do
+    filename=$(basename "$filepath")
     testname="${filename%.*}"
-    out=$(<"$DIR/$testname.out")
+    out=$(cat "$DIR/$testname.out")
 
     SKIP_TESTS="nonewline function decision everything syntax_error preemptive"
 
-    if echo $SKIP_TESTS | grep -w $testname > /dev/null; then
+    if echo "$SKIP_TESTS" | grep -w "$testname" > /dev/null; then
         continue
     fi
 
@@ -61,11 +61,11 @@ for filepath in $(find $DIR -maxdepth 1 -name '*.kaos'); do
 
     cd tests/
 
-    test=$(cat $filename | chaos 2>&1 | sed "s|.\[1;41m\s*||g" | sed "s|.\[0;41m\s*||g" \
+    test=$(cat "$filename" | chaos 2>&1 | sed "s|.\[1;41m\s*||g" | sed "s|.\[0;41m\s*||g" \
     | sed "s|.\[1;44m\s*||g" | sed "s|\s*.\[0m||g" | sed "s|.\[5;42m\s*||g" | sed "s|.\[0;90m.*||g" \
     | sed "s|.*\/chaos|File: \"~/chaos|g")
 
-    if [ "$test" == "$out" ]
+    if [ "$test" = "$out" ]
     then
         echo "OK"
     else
@@ -78,7 +78,7 @@ for filepath in $(find $DIR -maxdepth 1 -name '*.kaos'); do
 done
 
 if [ "$SHELL" = true ] ; then
-    $DIR/shell/interpreter.sh
+    "$DIR/shell/interpreter.sh"
 fi
 
 if [ "$failed" = true ] ; then

--- a/tests/memcheck.sh
+++ b/tests/memcheck.sh
@@ -1,32 +1,33 @@
-#!/bin/bash
+#!/bin/sh
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+OSTYPE=$(uname --kernel-name)
+DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
 
-for filepath in $(find $DIR -maxdepth 1 -name '*.kaos'); do
-    filename=$(basename $filepath)
+for filepath in $(find "$DIR" -maxdepth 1 -name '*.kaos'); do
+    filename=$(basename "$filepath")
     testname="${filename%.*}"
 
-    if [[ "$testname" == "exit_"* ]]; then
+    if [ "$testname" = "exit_*" ]; then
         continue
     fi
 
     SKIP_TESTS="syntax_error preemptive"
 
-    if echo $SKIP_TESTS | grep -w $testname > /dev/null; then
+    if echo "$SKIP_TESTS" | grep -w "$testname" > /dev/null; then
         continue
     fi
 
-    echo -e "\n\n(interpreter) Running memcheck: ${testname}\n"
+    printf "\n\n(interpreter) Running memcheck: %s\n" "$testname"
 
-    if [[ "$OSTYPE" == "linux"* ]]; then
-        valgrind --tool=memcheck --leak-check=full --show-reachable=yes --num-callers=20 --track-fds=yes --track-origins=yes --error-exitcode=1 chaos $DIR/$filename || exit 1
-    elif [[ "$OSTYPE" == "darwin"* ]]; then
-        /tmp/DrMemory/bin64/drmemory -exit_code_if_errors 1 -suppress tests/shell/suppress.mac.txt -- chaos $DIR/$filename || exit 1
+    if [ "$OSTYPE" = "Linux" ]; then
+        valgrind --tool=memcheck --leak-check=full --show-reachable=yes --num-callers=20 --track-fds=yes --track-origins=yes --error-exitcode=1 chaos "$DIR/$filename" || exit 1
+    elif [ "$OSTYPE" = "Darwin" ]; then
+        /tmp/DrMemory/bin64/drmemory -exit_code_if_errors 1 -suppress tests/shell/suppress.mac.txt -- chaos "$DIR/$filename" || exit 1
     fi
 done
 
-for dirpath in $(find $DIR -mindepth 1 -maxdepth 1 -type d); do
-    if [ -f $dirpath/memcheck.sh ]; then
-        $dirpath/memcheck.sh
+for dirpath in $(find "$DIR" -mindepth 1 -maxdepth 1 -type d); do
+    if [ -f "$dirpath/memcheck.sh" ]; then
+        "$dirpath/memcheck.sh"
     fi
 done

--- a/tests/memcheck_compiler.sh
+++ b/tests/memcheck_compiler.sh
@@ -1,53 +1,54 @@
-#!/bin/bash
+#!/bin/sh
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+OSTYPE=$(uname --kernel-name)
+DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
 
 TESTS_DIR=tests
 BUILD_DIR=build
 
-for filepath in $(find $DIR -maxdepth 1 -name '*.kaos'); do
-    filename=$(basename $filepath)
+for filepath in $(find "$DIR" -maxdepth 1 -name '*.kaos'); do
+    filename=$(basename "$filepath")
     testname="${filename%.*}"
 
-    if [[ "$testname" == "exit_"* ]]; then
+    if [ "$testname" = "exit_*" ]; then
         continue
     fi
 
     SKIP_TESTS="syntax_error preemptive"
 
-    if echo $SKIP_TESTS | grep -w $testname > /dev/null; then
+    if echo "$SKIP_TESTS" | grep -w "$testname" > /dev/null; then
         continue
     fi
 
-    echo -e "\n\n(compiler) Running memcheck: chaos -c ${TESTS_DIR}/${testname}\n"
+    printf "\n\n(compiler) Running memcheck: chaos -c %s/%s\n" "$TESTS_DIR" "$testname"
 
-    if [[ "$OSTYPE" == "linux"* ]]; then
-        valgrind --tool=memcheck --leak-check=full --show-reachable=yes --num-callers=20 --track-fds=yes --track-origins=yes --error-exitcode=1 chaos -c $DIR/$filename -o $testname || exit 1
-    elif [[ "$OSTYPE" == "darwin"* ]]; then
-        /tmp/DrMemory/bin64/drmemory -no_follow_children -exit_code_if_errors 1 -- chaos -c $DIR/$filename -o $testname || exit 1
+    if [ "$OSTYPE" = "Linux*" ]; then
+        valgrind --tool=memcheck --leak-check=full --show-reachable=yes --num-callers=20 --track-fds=yes --track-origins=yes --error-exitcode=1 chaos -c "$DIR/$filename" -o "$testname" || exit 1
+    elif [ "$OSTYPE" = "Darwin*" ]; then
+        /tmp/DrMemory/bin64/drmemory -no_follow_children -exit_code_if_errors 1 -- chaos -c "$DIR/$filename" -o "$testname" || exit 1
     fi
 done
 
-for filepath in $(find $DIR -maxdepth 1 -name '*.kaos'); do
-    filename=$(basename $filepath)
+for filepath in $(find "$DIR" -maxdepth 1 -name '*.kaos'); do
+    filename=$(basename "$filepath")
     testname="${filename%.*}"
 
-    if [[ "$testname" == "exit_"* ]]; then
+    if [ "$testname" = "exit_*" ]; then
         continue
     fi
 
     SKIP_TESTS="syntax_error preemptive"
 
-    if echo $SKIP_TESTS | grep -w $testname > /dev/null; then
+    if echo "$SKIP_TESTS" | grep -w "$testname" > /dev/null; then
         continue
     fi
 
-    echo -e "\n\n(compiler) Running memcheck: ${BUILD_DIR}/${testname}\n"
+    printf "\n\n(compiler) Running memcheck: %s/%s\n" "$BUILD_DIR" "$testname"
 
-    if [[ "$OSTYPE" == "linux"* ]]; then
-        valgrind --tool=memcheck --leak-check=full --show-reachable=yes --num-callers=20 --track-fds=yes --track-origins=yes --error-exitcode=1 chaos $BUILD_DIR/$testname || exit 1
-    elif [[ "$OSTYPE" == "darwin"* ]]; then
-        /tmp/DrMemory/bin64/drmemory -no_follow_children -exit_code_if_errors 1 -- chaos $BUILD_DIR/$testname || exit 1
+    if [ "$OSTYPE" = "Linux*" ]; then
+        valgrind --tool=memcheck --leak-check=full --show-reachable=yes --num-callers=20 --track-fds=yes --track-origins=yes --error-exitcode=1 chaos "$BUILD_DIR/$testname" || exit 1
+    elif [ "$OSTYPE" = "Darwin*" ]; then
+        /tmp/DrMemory/bin64/drmemory -no_follow_children -exit_code_if_errors 1 -- chaos "$BUILD_DIR/$testname" || exit 1
     fi
 done
 

--- a/tests/official_spells.sh
+++ b/tests/official_spells.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 UNAME_S=$(uname -s)
 
@@ -7,8 +7,8 @@ test_spell() {
         printf '%s\n' "Removing directory: $1"
         rm -rf "$1"
     fi
-    git clone https://github.com/chaos-lang/$1.git --depth 1 && \
-    cd $1/ && \
+    git clone "https://github.com/chaos-lang/$1.git" --depth 1 && \
+    cd "$1"/ && \
     make && \
     make test && \
     make test-compiler && \
@@ -28,12 +28,12 @@ test_spell() {
 
 echo "Testing all official spells"
 
-SPELL_LIST=(math string array json)
+SPELL_LIST="math string array json"
 
 mkdir -p .build && \
 cd .build && \
 
-for spell in ${SPELL_LIST[*]}
+for spell in $SPELL_LIST
 do
-    test_spell $spell || exit 1
+    test_spell "$spell" || exit 1
 done

--- a/tests/rosetta/compiler.sh
+++ b/tests/rosetta/compiler.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 extra_flags=""
 EXTRA_FLAGS_ENABLED=false
@@ -19,21 +19,21 @@ while getopts ":e:" opt; do
     esac
 done
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
 
 failed=false
 
-for filepath in $(find $DIR -maxdepth 1 -name '*.kaos'); do
-    filename=$(basename $filepath)
+for filepath in $(find "$DIR" -maxdepth 1 -name '*.kaos'); do
+    filename=$(basename "$filepath")
     testname="${filename%.*}"
-    out=$(<"$DIR/$testname.out")
+    out=$(cat "$DIR/$testname.out")
 
     echo "(compiler) Compiling test: ${testname}"
 
     if [ "$EXTRA_FLAGS_ENABLED" = true ] ; then
-        cout=$(chaos -c tests/rosetta/$filename -o $testname -e "$extra_flags")
+        cout=$(chaos -c "tests/rosetta/$filename" -o "$testname" -e "$extra_flags")
     else
-        cout=$(chaos -c tests/rosetta/$filename -o $testname)
+        cout=$(chaos -c "tests/rosetta/$filename" -o "$testname")
     fi
     status=$?
 
@@ -47,15 +47,15 @@ for filepath in $(find $DIR -maxdepth 1 -name '*.kaos'); do
     fi
 done
 
-for filepath in $(find $DIR -maxdepth 1 -name '*.kaos'); do
-    filename=$(basename $filepath)
+for filepath in $(find "$DIR" -maxdepth 1 -name '*.kaos'); do
+    filename=$(basename "$filepath")
     testname="${filename%.*}"
-    out=$(<"$DIR/$testname.out")
+    out=$(cat "$DIR/$testname.out")
 
     echo "(compiler) Running test: ${testname}"
 
-    test=$(build/$testname)
-    if [ "$test" == "$out" ]
+    test="build/$testname"
+    if [ "$test" = "$out" ]
     then
         echo "OK"
     else

--- a/tests/rosetta/install.sh
+++ b/tests/rosetta/install.sh
@@ -1,13 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 
 install_spell() {
     if [ -d "$1" ]; then
         printf '%s\n' "Removing directory: $1"
         rm -rf "$1"
     fi
-    git clone https://github.com/chaos-lang/$1.git --depth 1 && \
-    cd $1/ && \
-    if [ "$2" == "clang" ]; then
+    git clone "https://github.com/chaos-lang/$1.git" --depth 1 && \
+    cd "$1/" && \
+    if [ "$2" = "clang" ]; then
         make clang
     else
         make
@@ -17,13 +17,13 @@ install_spell() {
 
 echo "Installing all official spells"
 
-SPELL_LIST=(math string array json)
+SPELL_LIST="math string array json"
 
 mkdir -p tests/rosetta/spells && \
 cd tests/rosetta/spells && \
 
-for spell in ${SPELL_LIST[*]}
+for spell in $SPELL_LIST
 do
-    install_spell $spell $1 || exit 1
+    install_spell "$spell" "$1" || exit 1
 done
 

--- a/tests/rosetta/interpreter.sh
+++ b/tests/rosetta/interpreter.sh
@@ -1,18 +1,18 @@
-#!/bin/bash
+#!/bin/sh
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
 
 failed=false
 
-for filepath in $(find $DIR -maxdepth 1 -name '*.kaos'); do
-    filename=$(basename $filepath)
+for filepath in $(find "$DIR" -maxdepth 1 -name '*.kaos'); do
+    filename=$(basename "$filepath")
     testname="${filename%.*}"
-    out=$(<"$DIR/$testname.out")
+    out=$(cat "$DIR/$testname.out")
 
-    echo "(interpreter) Running test: ${testname}"
+    echo "(interpreter) Running test: $testname"
 
-    test=$(chaos tests/rosetta/$filename)
-    if [ "$test" == "$out" ]
+    test=$(chaos "tests/rosetta/$filename")
+    if [ "$test" = "$out" ]
     then
         echo "OK"
     else

--- a/tests/rosetta/update.sh
+++ b/tests/rosetta/update.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
 
-for filepath in $(find $DIR -maxdepth 1 -name '*.kaos'); do
-    filename=$(basename $filepath)
+for filepath in $(find "$DIR" -maxdepth 1 -name '*.kaos'); do
+    filename=$(basename "$filepath")
     testname="${filename%.*}"
     rm "$DIR/$testname.out"
     chaos "tests/rosetta/$filename" > "$DIR/$testname.out"

--- a/tests/shell/interpreter.sh
+++ b/tests/shell/interpreter.sh
@@ -1,26 +1,27 @@
-#!/bin/bash
+#!/bin/sh
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-SUB="$( basename $DIR )"
+OSTYPE=$(uname --kernel-name)
+DIR="$( cd "$( dirname "0" )" >/dev/null 2>&1 && pwd )"
+SUB="$( basename "$DIR" )"
 
-if [[ "$OSTYPE" == "darwin"* ]]; then
+if [ "$OSTYPE" = "Darwin*" ]; then
     shopt -s expand_aliases
     alias sed='gsed'
 fi
 
 failed=false
 
-for filepath in $(find $DIR -maxdepth 1 -name '*.kaos'); do
-    filename=$(basename $filepath)
+for filepath in $(find "$DIR" -maxdepth 1 -name '*.kaos'); do
+    filename=$(basename "$filepath")
     testname="${filename%.*}"
-    out=$(<"$DIR/$testname.out")
+    out=$(cat "$DIR/$testname.out")
 
-    echo "(interpreter) Running test: ${SUB}/${testname}"
+    echo "(interpreter) Running test: $SUB/$testname"
 
-    test=$(cat $DIR/$filename | chaos 2>&1 | sed "s|.\[1;41m\s*||g" | sed "s|.\[0;41m\s*||g" \
+    test=$(cat "$DIR/$filename" | chaos 2>&1 | sed "s|.\[1;41m\s*||g" | sed "s|.\[0;41m\s*||g" \
     | sed "s|.\[1;44m\s*||g" | sed "s|\s*.\[0m||g" | sed "s|.\[5;42m\s*||g" | sed "s|.\[0;90m.*||g" \
     | sed "s|.*\/chaos|File: \"~/chaos|g")
-    if [ "$test" == "$out" ]
+    if [ "$test" = "$out" ]
     then
         echo "OK"
     else

--- a/tests/shell/memcheck.sh
+++ b/tests/shell/memcheck.sh
@@ -1,17 +1,18 @@
-#!/bin/bash
+#!/bin/sh
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-SUB="$( basename $DIR )"
+OSTYPE=$(uname --kernel-name)
+DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
+SUB="$( basename "$DIR" )"
 
-for filepath in $(find $DIR -maxdepth 1 -name '*.kaos' ! -name '*_fail.kaos'); do
-    filename=$(basename $filepath)
+for filepath in $(find "$DIR" -maxdepth 1 -name '*.kaos' ! -name '*_fail.kaos'); do
+    filename=$(basename "$filepath")
     testname="${filename%.*}"
 
-    echo -e "\n\nRunning memcheck: ${SUB}/${testname}\n"
+    printf "\n\nRunning memcheck: %s/%s\n" "$SUB" "$testname"
 
-    if [[ "$OSTYPE" == "linux"* ]]; then
-        cat $DIR/$filename | valgrind --tool=memcheck --leak-check=full --show-reachable=yes --num-callers=20 --track-fds=yes --track-origins=yes --error-exitcode=1 chaos || exit 1
-    elif [[ "$OSTYPE" == "darwin"* ]]; then
-        cat $DIR/$filename | /tmp/DrMemory/bin64/drmemory -exit_code_if_errors 1 -suppress suppress.mac.txt -- chaos || exit 1
+    if [ "$OSTYPE" = "Linux*" ]; then
+        cat "$DIR/$filename" | valgrind --tool=memcheck --leak-check=full --show-reachable=yes --num-callers=20 --track-fds=yes --track-origins=yes --error-exitcode=1 chaos || exit 1
+    elif [ "$OSTYPE" = "Darwin*" ]; then
+        cat "$DIR/$filename" | /tmp/DrMemory/bin64/drmemory -exit_code_if_errors 1 -suppress suppress.mac.txt -- chaos || exit 1
     fi
 done

--- a/tests/shell/update.sh
+++ b/tests/shell/update.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-SUB="$( basename $DIR )"
+DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
+SUB="$( basename "$DIR" )"
 
-for filepath in $(find $DIR -maxdepth 1 -name '*.kaos'); do
-    filename=$(basename $filepath)
+for filepath in $(find "$DIR" -maxdepth 1 -name '*.kaos'); do
+    filename=$(basename "$filepath")
     testname="${filename%.*}"
     rm "$DIR/$testname.out"
     cat "$DIR/$filename" | chaos > "$DIR/$testname.out" 2>&1

--- a/tests/update.sh
+++ b/tests/update.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
 
-for filepath in $(find $DIR -maxdepth 1 -name '*.kaos'); do
-    filename=$(basename $filepath)
+for filepath in $(find "$DIR" -maxdepth 1 -name '*.kaos'); do
+    filename=$(basename "$filepath")
     testname="${filename%.*}"
     rm "$DIR/$testname.out"
     chaos "tests/$filename" > "$DIR/$testname.out" 2>&1
@@ -11,4 +11,4 @@ for filepath in $(find $DIR -maxdepth 1 -name '*.kaos'); do
     echo "Updated: ${testname}"
 done
 
-$DIR/shell/update.sh
+"$DIR/shell/update.sh"


### PR DESCRIPTION
## Pull Request Details

### Description

This PR replaces the Bash scripts with POSIX sh scripts.

### Related Issue

This is to address PR #100.

### Motivation and Context

Bash inherently has portability problems because it breaks POSIX compliance. Upgrading our shell scripts to be POSIX compliant will help with portability and drawing in new users.

### How Has This Been Tested

TODO

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)

### Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
